### PR TITLE
Increasing number of `modifiedexistingcount` required before returning true

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -116,7 +116,7 @@ class RansomwareFileModifications(Signature):
                 self.description += ": appends_email_to_filenames"
             ret = True
 
-        if self.modifiedexistingcount > 50:
+        if self.modifiedexistingcount > 100:
             if ":" in self.description:
                 self.description += " overwrites_existing_files"
             else:


### PR DESCRIPTION
This signature was being raised a lot on benign files, since the number of `modifiedexistingcount` hovered around 60 for an average file.