### PR TITLE
Fix bug in encrypt_pcinfo signature

### DIFF
--- a/modules/signatures/windows/malware_data_encryption.py
+++ b/modules/signatures/windows/malware_data_encryption.py
@@ -36,6 +36,7 @@ class EncryptPCInfo(Signature):
         self.ret = False
         self.compname = str()
         self.username = str()
+        self.check_buffers = False
         self.buffers = set()
         self.safelistprocs = ["winword.exe", "excel.exe", "powerpoint.exe", "acrobat.exe"]
 
@@ -43,14 +44,17 @@ class EncryptPCInfo(Signature):
         if process["process_name"].lower() not in self.safelistprocs:
             if call["api"] == "GetComputerNameW":
                 self.compname = self.get_argument(call, "ComputerName")
+                self.check_buffers = True
 
-            if call["api"] == "GetUserNameW":
+            elif call["api"] == "GetUserNameW":
                 self.username = self.get_argument(call, "Name")
+                self.check_buffers = True
 
-            if call["api"].startswith("Crypt"):
+            elif self.check_buffers and call["api"].startswith("Crypt"):
                 buff = self.get_argument(call, "Buffer")
-                if buff and (self.username or self.compname):
-                    if self.compname.lower() in buff.lower() or self.username.lower() in buff.lower():
+                if buff:
+                    buff_lower = buff.lower()
+                    if any(n.lower() in buff_lower for n in [self.compname, self.username] if n):
                         self.ret = True
                         self.buffers.add(buff)
                         if self.pid:


### PR DESCRIPTION
When only one of `[compname, username]` is set, the `Crypt*` buffers are checked against an empty string making the condition always pass.