### PR TITLE
fix signatures/wndows/virus.py infinite loop

### DIFF
--- a/modules/signatures/windows/virus.py
+++ b/modules/signatures/windows/virus.py
@@ -96,8 +96,10 @@ class Virus(Signature):
             if handle in self.handles:
                 key = self.handles[handle]
                 if key in self.copydests:
-                    while key in self.readcopyfiles:
+                    key_max_depth = 3
+                    while key_max_depth and key in self.readcopyfiles:
                         key = self.readcopyfiles[key]
+                        key_max_depth -= 1
                 self.infected_files.add(key)
                 self.saw_virus = True
                 if self.pid:


### PR DESCRIPTION
This plugin introduces a while condition that can end up becoming an infinite loop. 

Seen in SHA256: 

- 0b577cbf1914b04d92c9a07fe5bca8e07451573ad3ea11299948edcd1ec86413

- 0757a85f8e19e972ea6e140d8b5f69f58b533471c0b5a603005fa0ca9667d48a
