### PR TITLE
Change the logic of detection

### DIFF
--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -62,26 +62,26 @@ class BrowserStealer(Signature):
             re.compile(".*\\\\Microsoft\\\\Edge\\\\User\\ Data\\\\Default\\\\.*", re.I),
 
             # Google Chrome
-            re.compile(".*\\\\Application Data\\\\Google\\\\Chrome\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Google\\\\Chrome\\\\.*", re.I),
             re.compile(".*\\\\Local\\\\Google\\\\Chrome\\\\User\\ Data\\\\Default\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User\\ Data\\\\Default\\\\.*", re.I),
 
             # Chromium-based Browsers
-            re.compile(".*\\\\Application Data\\\\Chromium\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Chromium\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Local\\\\Chromium\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\ChromePlus\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\ChromePlus\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Local\\\\MapleStudio\\\\ChromePlus\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\Nichrome\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\Bromium\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\RockMelt\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\Flock\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Nichrome\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Bromium\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\RockMelt\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Flock\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Local\\\\Flock\\\\.*", re.I),
-            re.compile(".*\\\\Application Data\\\\Comodo\\\\Dragon\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Comodo\\\\Dragon\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Local\\\\Comodo\\\\Dragon\\\\.*", re.I),
             re.compile(".*\\\\BraveSoftware\\\\Brave-Browser\\\\User\\ Data\\\\Default\\\\.*", re.I),
 
             # Opera
-            re.compile(".*\\\\Application Data\\\\Opera\\\\.*", re.I),
+            re.compile(".*\\\\Application\\ Data Data\\\\Opera\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Roaming\\\\Opera\\\\Opera\\\\.*", re.I),
             re.compile(".*\\\\AppData\\\\Roaming\\\\Opera Software\\\\Opera Stable\\\\.*", re.I),
 

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -36,7 +36,7 @@ class BrowserStealer(Signature):
     mbcs = ["OB0005"]
     mbcs += ["OC0001", "C0051"]  # micro-behaviour
 
-    filter_apinames = set(["NtReadFile", "CopyFileA", "CopyFileW", "CopyFileExW", "NtQueryAttributesFile"])
+    filter_apinames = set(["NtQueryAttributesFile", "CopyFileA", "CopyFileW", "CopyFileExW"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -109,8 +109,12 @@ class BrowserStealer(Signature):
             return None
 
         filename = None
-        if call["api"] == "NtQueryAttributesFile":
+        if call["api"] == "NtReadFile":
+            filename = self.get_argument(call, "HandleName")
+        elif call["api"] == "NtQueryAttributesFile":
             filename = self.get_argument(call, "FileName")
+        else:
+            filename = self.get_argument(call, "ExistingFileName")
         if not filename:
             return None
 

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -62,26 +62,26 @@ class BrowserStealer(Signature):
             re.compile(r".*\\Microsoft\\Edge\\User\\ Data\\Default\\.*", re.I),
 
             # Google Chrome
-            re.compile(r".*\\Application\\ Data Data\\Google\\Chrome\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Google\\Chrome\\.*", re.I),
             re.compile(r".*\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
 
             # Chromium-based Browsers
-            re.compile(r".*\\Application\\ Data Data\\Chromium\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Chromium\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Chromium\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\ChromePlus\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\ChromePlus\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\MapleStudio\\ChromePlus\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\Nichrome\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\Bromium\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\RockMelt\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\Flock\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Nichrome\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Bromium\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\RockMelt\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Flock\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Flock\\.*", re.I),
-            re.compile(r".*\\Application\\ Data Data\\Comodo\\Dragon\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Comodo\\Dragon\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Comodo\\Dragon\\.*", re.I),
             re.compile(r".*\\BraveSoftware\\Brave-Browser\\User\\ Data\\Default\\.*", re.I),
 
             # Opera
-            re.compile(r".*\\Application\\ Data Data\\Opera\\.*", re.I),
+            re.compile(r".*\\Application\\ Data\\Opera\\.*", re.I),
             re.compile(r".*\\AppData\\Roaming\\Opera\\Opera\\.*", re.I),
             re.compile(r".*\\AppData\\Roaming\\Opera Software\\Opera Stable\\.*", re.I),
 

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -46,61 +46,61 @@ class BrowserStealer(Signature):
         self.saw_stealer = False
         self.indicators = [
             # Firefox
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\signons\.sqlite$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\cookies\.sqlite$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\secmod\.db$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\cert8\.db$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\key3\.db$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\places\.sqlite$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\logins\.json$", re.I),
-            re.compile(".*\\\\Mozilla\\\\Firefox\\\\Profiles\\\\.*\\\\.default\\\\formhistory\.sqlite$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\signons\.sqlite$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\cookies\.sqlite$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\secmod\.db$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\cert8\.db$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\key3\.db$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\places\.sqlite$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\logins\.json$", re.I),
+            re.compile(r".*\\Mozilla\\Firefox\\Profiles\\.*\\.default\\formhistory\.sqlite$", re.I),
 
             # Internet Explorer/Edge
-            re.compile(".*\\\\History\\\\History.IE5\\\\index\.dat$", re.I),
-            re.compile(".*\\\\Cookies\\\\.*", re.I),
-            re.compile(".*\\\\Temporary Internet Files\\\\Content.IE5\\\\index\.dat$", re.I),
-            re.compile(".*\\\\Microsoft\\\\Edge\\\\User\\ Data\\\\Default\\\\.*", re.I),
+            re.compile(r".*\\History\\History.IE5\\index\.dat$", re.I),
+            re.compile(r".*\\Cookies\\.*", re.I),
+            re.compile(r".*\\Temporary Internet Files\\Content.IE5\\index\.dat$", re.I),
+            re.compile(r".*\\Microsoft\\Edge\\User\\ Data\\Default\\.*", re.I),
 
             # Google Chrome
-            re.compile(".*\\\\Application\\ Data Data\\\\Google\\\\Chrome\\\\.*", re.I),
-            re.compile(".*\\\\Local\\\\Google\\\\Chrome\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User\\ Data\\\\Default\\\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Google\\Chrome\\.*", re.I),
+            re.compile(r".*\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
 
             # Chromium-based Browsers
-            re.compile(".*\\\\Application\\ Data Data\\\\Chromium\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Chromium\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\ChromePlus\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\MapleStudio\\\\ChromePlus\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\Nichrome\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\Bromium\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\RockMelt\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\Flock\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Flock\\\\.*", re.I),
-            re.compile(".*\\\\Application\\ Data Data\\\\Comodo\\\\Dragon\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Comodo\\\\Dragon\\\\.*", re.I),
-            re.compile(".*\\\\BraveSoftware\\\\Brave-Browser\\\\User\\ Data\\\\Default\\\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Chromium\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Chromium\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\ChromePlus\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\MapleStudio\\ChromePlus\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Nichrome\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Bromium\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\RockMelt\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Flock\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Flock\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Comodo\\Dragon\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Comodo\\Dragon\\.*", re.I),
+            re.compile(r".*\\BraveSoftware\\Brave-Browser\\User\\ Data\\Default\\.*", re.I),
 
             # Opera
-            re.compile(".*\\\\Application\\ Data Data\\\\Opera\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Roaming\\\\Opera\\\\Opera\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Roaming\\\\Opera Software\\\\Opera Stable\\\\.*", re.I),
+            re.compile(r".*\\Application\\ Data Data\\Opera\\.*", re.I),
+            re.compile(r".*\\AppData\\Roaming\\Opera\\Opera\\.*", re.I),
+            re.compile(r".*\\AppData\\Roaming\\Opera Software\\Opera Stable\\.*", re.I),
 
             # Safari
-            re.compile(".*\\\\Apple Computer\\\\Safari\\\\WebpageIcons\.db$", re.I),
-            re.compile(".*\\\\Apple Computer\\\\Safari\\\\History\.db$", re.I),
-            re.compile(".*\\\\Apple Computer\\\\Safari\\\\LastSession\.plist$", re.I),
+            re.compile(r".*\\Apple Computer\\Safari\\WebpageIcons\.db$", re.I),
+            re.compile(r".*\\Apple Computer\\Safari\\History\.db$", re.I),
+            re.compile(r".*\\Apple Computer\\Safari\\LastSession\.plist$", re.I),
 
             # Others
-            re.compile(".*\\\\AppData\\\\Local\\\\Spark\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Nichrome\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Titan Browser\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Rockmelt\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\Torch\\\\User\\ Data\\\\Default\\\\.*", re.I),
-            re.compile(".*\\\\AppData\\\\Local\\\\.*\\\\YandexBrowser\\\\User\\ Data\\\\Default\\\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Spark\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Nichrome\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Titan Browser\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Rockmelt\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Torch\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\.*\\YandexBrowser\\User\\ Data\\Default\\.*", re.I),
         ]
 
     def on_call(self, call, process):
-        
+
 
         # If the current process appears to be a browser, continue.
         # TODO: implement better checks here -- the malware can be named whatever it wants or can

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -59,29 +59,32 @@ class BrowserStealer(Signature):
             re.compile(r".*\\History\\History.IE5\\index\.dat$", re.I),
             re.compile(r".*\\Cookies\\.*", re.I),
             re.compile(r".*\\Temporary Internet Files\\Content.IE5\\index\.dat$", re.I),
-            re.compile(r".*\\Microsoft\\Edge\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\Microsoft\\Edge\\User Data\\Default\\.*", re.I),
 
             # Google Chrome
-            re.compile(r".*\\Application\\ Data\\Google\\Chrome\\.*", re.I),
-            re.compile(r".*\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\Google\\Chrome\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Google\\Chrome\\.*", re.I),
+            re.compile(r".*\\Local\\Google\\Chrome\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\.*", re.I),
 
             # Chromium-based Browsers
-            re.compile(r".*\\Application\\ Data\\Chromium\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Chromium\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Chromium\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\ChromePlus\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\ChromePlus\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\MapleStudio\\ChromePlus\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\Nichrome\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\Bromium\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\RockMelt\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\Flock\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Nichrome\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Nichrome\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Bromium\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Bromium\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\RockMelt\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\RockMelt\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Flock\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Flock\\.*", re.I),
-            re.compile(r".*\\Application\\ Data\\Comodo\\Dragon\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Comodo\\Dragon\\.*", re.I),
             re.compile(r".*\\AppData\\Local\\Comodo\\Dragon\\.*", re.I),
-            re.compile(r".*\\BraveSoftware\\Brave-Browser\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\BraveSoftware\\Brave-Browser\\User Data\\Default\\.*", re.I),
 
             # Opera
-            re.compile(r".*\\Application\\ Data\\Opera\\.*", re.I),
+            re.compile(r".*\\Application\\User Data\\Opera\\.*", re.I),
             re.compile(r".*\\AppData\\Roaming\\Opera\\Opera\\.*", re.I),
             re.compile(r".*\\AppData\\Roaming\\Opera Software\\Opera Stable\\.*", re.I),
 
@@ -91,17 +94,15 @@ class BrowserStealer(Signature):
             re.compile(r".*\\Apple Computer\\Safari\\LastSession\.plist$", re.I),
 
             # Others
-            re.compile(r".*\\AppData\\Local\\Spark\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\Nichrome\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\Titan Browser\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\Rockmelt\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\Torch\\User\\ Data\\Default\\.*", re.I),
-            re.compile(r".*\\AppData\\Local\\.*\\YandexBrowser\\User\\ Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Spark\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Nichrome\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Titan Browser\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Rockmelt\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\Torch\\User Data\\Default\\.*", re.I),
+            re.compile(r".*\\AppData\\Local\\.*\\YandexBrowser\\User Data\\Default\\.*", re.I),
         ]
 
     def on_call(self, call, process):
-
-
         # If the current process appears to be a browser, continue.
         # TODO: implement better checks here -- the malware can be named whatever it wants or can
         # inject into browser processes

--- a/modules/signatures/windows/infostealer_browser.py
+++ b/modules/signatures/windows/infostealer_browser.py
@@ -40,6 +40,8 @@ class BrowserStealer(Signature):
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
+        self.MALICIOUS_ARTIFACTS_THRESHOLD = 3
+        self.artifacts_counter = 0
         self.filematches = set()
         self.saw_stealer = False
         self.indicators = [
@@ -98,6 +100,8 @@ class BrowserStealer(Signature):
         ]
 
     def on_call(self, call, process):
+        
+
         # If the current process appears to be a browser, continue.
         # TODO: implement better checks here -- the malware can be named whatever it wants or can
         # inject into browser processes
@@ -116,8 +120,11 @@ class BrowserStealer(Signature):
                 if self.pid:
                     self.mark_call()
                 self.saw_stealer = True
+                self.artifacts_counter += 1
 
     def on_complete(self):
-        for file in self.filematches:
-            self.data.append({"file": file})
-        return self.saw_stealer
+        if self.artifacts_counter >= self.MALICIOUS_ARTIFACTS_THRESHOLD:
+            for file in self.filematches:
+                self.data.append({"file": file})
+            return self.saw_stealer
+        return False


### PR DESCRIPTION
The signature is only triggered by the `NtReadFile` API, which requires the file to exist; however, if the browser is not installed on the guest VM, the signature won't be triggered. Most info stealers first check for the file's existence using the `PathFileExists` API, which internally calls the `NtQueryAttributesFile` API.

Also, I have added a counter to make the signature fired up if it hits a defined threshold, not in general to avoid false-positives.