### PR TITLE
Detecting Virtualization via RecentFiles

### DIFF
--- a/modules/signatures/windows/antivm_recent_files.py
+++ b/modules/signatures/windows/antivm_recent_files.py
@@ -1,0 +1,41 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class DetectVirtualizationViaRecentFiles(Signature):
+    name = "detect_virtualization_via_recent_files"
+    description = "Detects virtualization via checking the last access time of recent files"
+    severity = 3
+    categories = ["anti-vm"]
+    authors = ["@para0x0dise"]
+    minimum = "0.5"
+    evented = True
+    ttps = ["T1497", "T1083"]
+    references = [
+        "https://www.linkedin.com/posts/malcore_today-we-will-be-continuing-our-vm-detection-activity-7257056918160986115-Ihh9?utm_source=share&utm_medium=member_desktop"
+    ]
+
+    filter_apinames = set(["SHGetFolderPathW", "FindFirstFileExW"])
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.recents = False
+        self.enumerate = False
+
+    def on_call(self, call, _):
+        if call["api"] == "SHGetFolderPathW":
+            folder = self.get_argument(call, "Folder")
+            if folder == '0x00000008':   # CSIDL_RECENT
+                if self.pid:
+                    self.mark_call()
+                self.recents = True
+
+        if call["api"] == "FindFirstFileExW":
+            folder = self.get_argument(call, "FileName").lower()
+            if "\\windows\\recent\\" in folder:
+                if self.pid:
+                    self.mark_call()
+                self.enumerate = True
+
+    def on_complete(self):
+        if self.recents and self.enumerate:
+            return True
+        return False


### PR DESCRIPTION
According to [Malcore](https://www.linkedin.com/posts/malcore_today-we-will-be-continuing-our-vm-detection-activity-7257056918160986115-Ihh9?utm_source=share&utm_medium=member_desktop), checking the last access time of recent files offers a clever approach to identifying virtualization environments. If recent files haven't been accessed within a certain threshold, like 5 days, it could indicate the system is running on a virtual machine.