### PR TITLE
Remove the path check in PDF_Annot_URLs_Checker.__init__

### DIFF
--- a/modules/signatures/all/pdf_annot_urls.py
+++ b/modules/signatures/all/pdf_annot_urls.py
@@ -55,9 +55,7 @@ class PDF_Annot_URLs_Checker(Signature):
 
     def __init__(self, *args, **kwargs):
         super(PDF_Annot_URLs_Checker, self).__init__(*args, **kwargs)
-        self.malicious_tlds = set()
-        if os.path.exists(self.malicious_tlds_file):
-            self.malicious_tlds = self.load_malicious_tlds()
+        self.malicious_tlds = self.load_malicious_tlds()
 
     def load_malicious_tlds(self):
         malicious_tlds = set()


### PR DESCRIPTION
This path check references an undefined variable, causing CAPE processing to fail for every analysis.

The regression was introduced in c78f264a2fdb52d614c8da3aba4889718f5b905c.