### PR TITLE
Ensure raw_config from CAPE extractor is a dictionary before trying to parse it

### DIFF
--- a/modules/parsers/MACO/AgentTesla.py
+++ b/modules/parsers/MACO/AgentTesla.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict) -> MACOModel:
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return
 
     protocol = raw_config.get("Protocol")

--- a/modules/parsers/MACO/AsyncRAT.py
+++ b/modules/parsers/MACO/AsyncRAT.py
@@ -8,7 +8,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict) -> MACOModel:
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return
 
     parsed_result = MACOModel(family="AsyncRAT", other=raw_config)

--- a/modules/parsers/MACO/AuroraStealer.py
+++ b/modules/parsers/MACO/AuroraStealer.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="AuroraStealer", other=raw_config)

--- a/modules/parsers/MACO/Azorult.py
+++ b/modules/parsers/MACO/Azorult.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     return MACOModel(

--- a/modules/parsers/MACO/BackOffLoader.py
+++ b/modules/parsers/MACO/BackOffLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BackOffLoader", other=raw_config)

--- a/modules/parsers/MACO/BackOffPOS.py
+++ b/modules/parsers/MACO/BackOffPOS.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BackOffPOS", other=raw_config)

--- a/modules/parsers/MACO/BitPaymer.py
+++ b/modules/parsers/MACO/BitPaymer.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BitPaymer", other=raw_config)

--- a/modules/parsers/MACO/BlackDropper.py
+++ b/modules/parsers/MACO/BlackDropper.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BlackDropper", campaign_id=[raw_config["campaign"]], other=raw_config)

--- a/modules/parsers/MACO/BlackNix.py
+++ b/modules/parsers/MACO/BlackNix.py
@@ -8,7 +8,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BlackNix", other=raw_config)

--- a/modules/parsers/MACO/Blister.py
+++ b/modules/parsers/MACO/Blister.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Blister", other=raw_config)

--- a/modules/parsers/MACO/BruteRatel.py
+++ b/modules/parsers/MACO/BruteRatel.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BruteRatel", other=raw_config)

--- a/modules/parsers/MACO/BuerLoader.py
+++ b/modules/parsers/MACO/BuerLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BuerLoader", other=raw_config)

--- a/modules/parsers/MACO/BumbleBee.py
+++ b/modules/parsers/MACO/BumbleBee.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="BumbleBee", other=raw_config)

--- a/modules/parsers/MACO/Carbanak.py
+++ b/modules/parsers/MACO/Carbanak.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Carbanak", other=raw_config)

--- a/modules/parsers/MACO/ChChes.py
+++ b/modules/parsers/MACO/ChChes.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="ChChes", other=raw_config)

--- a/modules/parsers/MACO/CobaltStrikeBeacon.py
+++ b/modules/parsers/MACO/CobaltStrikeBeacon.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="CobaltStrikeBeacon", other=raw_config)

--- a/modules/parsers/MACO/CobaltStrikeStager.py
+++ b/modules/parsers/MACO/CobaltStrikeStager.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="CobaltStrikeStager", other=raw_config)

--- a/modules/parsers/MACO/DCRat.py
+++ b/modules/parsers/MACO/DCRat.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     # TODO: Assign fields to MACO model

--- a/modules/parsers/MACO/DarkGate.py
+++ b/modules/parsers/MACO/DarkGate.py
@@ -8,7 +8,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="DarkGate", other=raw_config)

--- a/modules/parsers/MACO/DoppelPaymer.py
+++ b/modules/parsers/MACO/DoppelPaymer.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="DoppelPaymer")

--- a/modules/parsers/MACO/DridexLoader.py
+++ b/modules/parsers/MACO/DridexLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="DridexLoader", other=raw_config)

--- a/modules/parsers/MACO/Emotet.py
+++ b/modules/parsers/MACO/Emotet.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Emotet", other=raw_config)

--- a/modules/parsers/MACO/Enfal.py
+++ b/modules/parsers/MACO/Enfal.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     # TODO: Assign fields to MACO model

--- a/modules/parsers/MACO/EvilGrab.py
+++ b/modules/parsers/MACO/EvilGrab.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="EvilGrab", other=raw_config)

--- a/modules/parsers/MACO/Fareit.py
+++ b/modules/parsers/MACO/Fareit.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     # TODO: Assign fields to MACO model

--- a/modules/parsers/MACO/Formbook.py
+++ b/modules/parsers/MACO/Formbook.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Formbook", other=raw_config)

--- a/modules/parsers/MACO/Greame.py
+++ b/modules/parsers/MACO/Greame.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Greame", other=raw_config)

--- a/modules/parsers/MACO/GuLoader.py
+++ b/modules/parsers/MACO/GuLoader.py
@@ -8,7 +8,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="GuLoader", other=raw_config)

--- a/modules/parsers/MACO/Hancitor.py_deprecated.py
+++ b/modules/parsers/MACO/Hancitor.py_deprecated.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Hancitor", other=raw_config)

--- a/modules/parsers/MACO/HttpBrowser.py
+++ b/modules/parsers/MACO/HttpBrowser.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="HttpBrowser", other=raw_config)

--- a/modules/parsers/MACO/IcedID.py
+++ b/modules/parsers/MACO/IcedID.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     return MACOModel(**raw_config)

--- a/modules/parsers/MACO/IcedIDLoader.py
+++ b/modules/parsers/MACO/IcedIDLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="IcedIDLoader", other=raw_config)

--- a/modules/parsers/MACO/KoiLoader.py
+++ b/modules/parsers/MACO/KoiLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="KoiLoader", other=raw_config)

--- a/modules/parsers/MACO/Latrodectus.py
+++ b/modules/parsers/MACO/Latrodectus.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Latrodectus", other=raw_config)

--- a/modules/parsers/MACO/LokiBot.py
+++ b/modules/parsers/MACO/LokiBot.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="LokiBot", other=raw_config)

--- a/modules/parsers/MACO/Lumma.py
+++ b/modules/parsers/MACO/Lumma.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Lumma", other=raw_config)

--- a/modules/parsers/MACO/NanoCore.py
+++ b/modules/parsers/MACO/NanoCore.py
@@ -8,7 +8,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="NanoCore", other=raw_config)

--- a/modules/parsers/MACO/Nighthawk.py
+++ b/modules/parsers/MACO/Nighthawk.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Nighthawk", other=raw_config)

--- a/modules/parsers/MACO/Njrat.py
+++ b/modules/parsers/MACO/Njrat.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Njrat", other=raw_config)

--- a/modules/parsers/MACO/Oyster.py
+++ b/modules/parsers/MACO/Oyster.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Oyster", other=raw_config)

--- a/modules/parsers/MACO/Pandora.py
+++ b/modules/parsers/MACO/Pandora.py
@@ -9,7 +9,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     config_copy = deepcopy(raw_config)

--- a/modules/parsers/MACO/PhemedroneStealer.py
+++ b/modules/parsers/MACO/PhemedroneStealer.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="PhemedroneStealer", other=raw_config)

--- a/modules/parsers/MACO/PikaBot.py
+++ b/modules/parsers/MACO/PikaBot.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="PikaBot", other=raw_config)

--- a/modules/parsers/MACO/PlugX.py
+++ b/modules/parsers/MACO/PlugX.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="PlugX", other=raw_config)

--- a/modules/parsers/MACO/PoisonIvy.py
+++ b/modules/parsers/MACO/PoisonIvy.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="PoisonIvy", other=raw_config)

--- a/modules/parsers/MACO/Punisher.py
+++ b/modules/parsers/MACO/Punisher.py
@@ -9,7 +9,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     config_copy = deepcopy(raw_config)

--- a/modules/parsers/MACO/QakBot.py
+++ b/modules/parsers/MACO/QakBot.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="QakBot", other=raw_config)

--- a/modules/parsers/MACO/QuasarRAT.py
+++ b/modules/parsers/MACO/QuasarRAT.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="QuasarRAT", other=raw_config)

--- a/modules/parsers/MACO/Quickbind.py
+++ b/modules/parsers/MACO/Quickbind.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Quickbind", other=raw_config)

--- a/modules/parsers/MACO/RCSession.py
+++ b/modules/parsers/MACO/RCSession.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="RCSession", other=raw_config)

--- a/modules/parsers/MACO/REvil.py
+++ b/modules/parsers/MACO/REvil.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="REvil", other=raw_config)

--- a/modules/parsers/MACO/RedLeaf.py
+++ b/modules/parsers/MACO/RedLeaf.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="RedLeaf", other=raw_config)

--- a/modules/parsers/MACO/RedLine.py
+++ b/modules/parsers/MACO/RedLine.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="RedLine", other=raw_config)

--- a/modules/parsers/MACO/Remcos.py
+++ b/modules/parsers/MACO/Remcos.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Remcos", other=raw_config)

--- a/modules/parsers/MACO/Retefe.py
+++ b/modules/parsers/MACO/Retefe.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Retefe", other=raw_config)

--- a/modules/parsers/MACO/Rhadamanthys.py
+++ b/modules/parsers/MACO/Rhadamanthys.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Rhadamanthys", other=raw_config)

--- a/modules/parsers/MACO/Rozena.py
+++ b/modules/parsers/MACO/Rozena.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Rozena", other=raw_config)

--- a/modules/parsers/MACO/SmallNet.py
+++ b/modules/parsers/MACO/SmallNet.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="SmallNet", other=raw_config)

--- a/modules/parsers/MACO/SmokeLoader.py
+++ b/modules/parsers/MACO/SmokeLoader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(

--- a/modules/parsers/MACO/Socks5Systemz.py
+++ b/modules/parsers/MACO/Socks5Systemz.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(

--- a/modules/parsers/MACO/SparkRAT.py
+++ b/modules/parsers/MACO/SparkRAT.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="SparkRAT", other=raw_config)

--- a/modules/parsers/MACO/SquirrelWaffle.py
+++ b/modules/parsers/MACO/SquirrelWaffle.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(

--- a/modules/parsers/MACO/Stealc.py
+++ b/modules/parsers/MACO/Stealc.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(

--- a/modules/parsers/MACO/Strrat.py
+++ b/modules/parsers/MACO/Strrat.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Strrat", other=raw_config)

--- a/modules/parsers/MACO/TSCookie.py
+++ b/modules/parsers/MACO/TSCookie.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="TSCookie", other=raw_config)

--- a/modules/parsers/MACO/TrickBot.py
+++ b/modules/parsers/MACO/TrickBot.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="TrickBot", other=raw_config)

--- a/modules/parsers/MACO/UrsnifV3.py
+++ b/modules/parsers/MACO/UrsnifV3.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="UrsnifV3", other=raw_config)

--- a/modules/parsers/MACO/VenomRat.py
+++ b/modules/parsers/MACO/VenomRat.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="VenomRAT", other=raw_config)

--- a/modules/parsers/MACO/WarzoneRAT.py
+++ b/modules/parsers/MACO/WarzoneRAT.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="WarzoneRAT", other=raw_config)

--- a/modules/parsers/MACO/XWorm.py
+++ b/modules/parsers/MACO/XWorm.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="XWorm", other=raw_config)

--- a/modules/parsers/MACO/XenoRAT.py
+++ b/modules/parsers/MACO/XenoRAT.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="XenoRAT", other=raw_config)

--- a/modules/parsers/MACO/Zloader.py
+++ b/modules/parsers/MACO/Zloader.py
@@ -6,7 +6,7 @@ from modules.parsers.utils import get_YARA_rule
 
 
 def convert_to_MACO(raw_config: dict):
-    if not raw_config:
+    if not (raw_config and isinstance(raw_config, dict)):
         return None
 
     parsed_result = MACOModel(family="Zloader", other=raw_config)


### PR DESCRIPTION
Fixes a bug that can be raised if a CAPE extractor returns an exception string or anything non-dict.