### PR TITLE
Create ThreatFox Intel Sig

### DIFF
--- a/modules/signatures/all/intel_threatfox.py
+++ b/modules/signatures/all/intel_threatfox.py
@@ -61,10 +61,7 @@ class ThreatFox(Signature):
                     # Parse JSON and extract matches           
                     jsondata = json.dumps(response.json())
                     jsondict = json.loads(jsondata)
-                
-                    # Example returned JSON data section (jsondict['data'][0])
-                    # {'id': '1409315', 'ioc': '47.92.211.202:80', 'threat_type': 'botnet_cc', 'threat_type_desc': 'Indicator that identifies a botnet command&control server (C&C)', 'ioc_type': 'ip:port', 'ioc_type_desc': 'ip:port combination that is used for botnet Command&control (C&C)', 'malware': 'win.cobalt_strike', 'malware_printable': 'Cobalt Strike', 'malware_alias': 'Agentemis,BEACON,CobaltStrike,cobeacon', 'malware_malpedia': 'https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike', 'confidence_level': 50, 'first_seen': '2025-02-10 15:13:25 UTC', 'last_seen': None, 'reference': 'https://www.shodan.io/host/47.92.211.202#80', 'reporter': 'juroots', 'tags': ['c2', 'CobaltStrike', 'cs-watermark-987654321', 'shodan'], 'malware_samples': []}
-
+                    
                     iocdata = jsondict['data'][0]
                     if iocdata and iocdata != "Y":
                         self.data.append({"ioc_match": iocdata })

--- a/modules/signatures/all/intel_threatfox.py
+++ b/modules/signatures/all/intel_threatfox.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2025 Kevin Ross
+# Copyright (C) 2025 ThreatFox https://raw.githubusercontent.com/abusech/ThreatFox/refs/heads/main/threatfox_search_ioc.py
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+import urllib3
+import json
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ThreatFox(Signature):
+    name = "threatfox"
+    description = "Threatfox indicator matched"
+    severity = 3
+    categories = ["network"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    ttps = []
+
+    def run(self):
+        apikey = ""
+        ret = False
+  
+        #for host in self.results.get("network", {}).get("hosts", []):
+        #   ipaddress = host["ip"]
+        #    if ipaddress:
+        #       searchterm = ipaddress             
+
+        # Perform ThreatFox lookup for DNS results
+
+        if apikey:        
+            for dns in self.results.get("network", {}).get("domains", []):
+                query = dns["domain"]
+
+                if query:
+                    searchterm = query
+  
+                if searchterm:
+                    headers = {"Auth-Key" : apikey}
+                    data = {
+                       'query':            'search_ioc',
+                       'search_term':      searchterm
+                    }
+
+                    pool = urllib3.HTTPSConnectionPool('threatfox-api.abuse.ch', port=443, maxsize=50, headers=headers)
+
+                    json_data = json.dumps(data)
+                    response = pool.request("POST", "/api/v1/", body=json_data)
+
+                    # Parse JSON and extract matches           
+                    jsondata = json.dumps(response.json())
+                    jsondict = json.loads(jsondata)
+                
+                    # Example returned JSON data section (jsondict['data'][0])
+                    # {'id': '1409315', 'ioc': '47.92.211.202:80', 'threat_type': 'botnet_cc', 'threat_type_desc': 'Indicator that identifies a botnet command&control server (C&C)', 'ioc_type': 'ip:port', 'ioc_type_desc': 'ip:port combination that is used for botnet Command&control (C&C)', 'malware': 'win.cobalt_strike', 'malware_printable': 'Cobalt Strike', 'malware_alias': 'Agentemis,BEACON,CobaltStrike,cobeacon', 'malware_malpedia': 'https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike', 'confidence_level': 50, 'first_seen': '2025-02-10 15:13:25 UTC', 'last_seen': None, 'reference': 'https://www.shodan.io/host/47.92.211.202#80', 'reporter': 'juroots', 'tags': ['c2', 'CobaltStrike', 'cs-watermark-987654321', 'shodan'], 'malware_samples': []}
+
+                    iocdata = jsondict['data'][0]
+                    if iocdata and iocdata != "Y":
+                        self.data.append({"ioc_match": iocdata })
+                                 
+                        if iocdata['threat_type'] == "botnet_cc" and "Unknown malware" != iocdata['malware_printable']:                 
+                            self.families.append(iocdata['malware_printable'])
+                        ret = True
+
+                        if iocdata['threat_type'] == "botnet_cc":
+                            self.ttps.append("TA0011")
+                        if iocdata['threat_type'] == "payload_delivery":
+                            self.ttps.append("T1189")
+
+        return ret

--- a/modules/signatures/all/intel_threatfox.py
+++ b/modules/signatures/all/intel_threatfox.py
@@ -13,10 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import requests
-import urllib3
-import json
-
 from lib.cuckoo.common.abstracts import Signature
 
 class ThreatFox(Signature):

--- a/modules/signatures/all/intel_threatfox.py
+++ b/modules/signatures/all/intel_threatfox.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from lib.cuckoo.common.abstracts import Signature
+from lib.cuckoo.common.utils import add_family_detection
 
 class ThreatFox(Signature):
     name = "threatfox"
@@ -24,7 +25,7 @@ class ThreatFox(Signature):
     minimum = "1.3"
     ttps = []
 
-    def ioc_lookup(searchterm):
+    def ioc_lookup(self, searchterm):
         jsondict = self.check_threatfox(searchterm)
         if not jsondict:
             return
@@ -33,7 +34,7 @@ class ThreatFox(Signature):
         if iocdata and iocdata != "Y":
             self.data.append({"ioc_match": iocdata })         
             if iocdata['threat_type'] == "botnet_cc" and "Unknown malware" != iocdata['malware_printable']:                 
-                self.families.append(iocdata['malware_printable'])
+                add_family_detection(self.results, iocdata['malware_printable'], "Behavior", searchterm)
             self.ret = True
             if iocdata['threat_type'] == "botnet_cc":
                 self.ttps.append("TA0011")


### PR DESCRIPTION
This is an experimental signature for ThreatFox. It still needs the following assistance/work but if the api is entered from your threatfox account (free to create) this will work on DNS requests. 

So what is needed:
- I need to add in lookups for other network types (IP connections and other types if necessary)

The main thing is ideally is rather than the API being entered in the signature it is entered in processing.conf. I have created the following in my processing.conf under community:

[threatfox]
enabled = no
apikey = ""

My question is how do I call that checking that it is enabled and then more specifically how do I then pull the apikey from this into the signature.

So I think something like:
processing_conf = Config("processing")

if processing_conf.threatfox.enabled:
    apikey = GET_APIKEY (NEED HELP HERE)
    if apikey:
        rest of signature
        
        
![image](https://github.com/user-attachments/assets/d8e86c2f-9e00-47be-b013-c3095a06c63b)
