### PR TITLE
Create signature for reading memory of remote process

### DIFF
--- a/modules/signatures/windows/memory_scraping.py
+++ b/modules/signatures/windows/memory_scraping.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2025 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ReadsMemoryRemoteProcess(Signature):
+    name = "reads_memory_remote_process"
+    description = "Reads from the memory of another process"
+    severity = 2
+    categories = ["memory scraping", "injection"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    filter_apinames = set(["ReadProcessMemory"])
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+
+    def on_call(self, call, process):
+            prochandle = self.get_argument(call, "ProcessHandle")
+            if prochandle not in ["0x00000000","0x0000000000000000","0xffffffff","0xffffffffffffffff"]:
+                buf = self.get_argument(call, "Buffer")
+                if len(buf) > 0:
+                    self.mark_call()
+                    self.ret = True
+
+    def on_complete(self):
+        return self.ret

--- a/modules/signatures/windows/memory_scraping.py
+++ b/modules/signatures/windows/memory_scraping.py
@@ -43,7 +43,7 @@ class ReadsMemoryRemoteProcess(Signature):
                     if processid not in self.sourcepids and prochandle not in self.targethandles:
                         self.data.append({"read_memory": "Process %s with process ID %s read from the memory of process handle %s" % (pname, processid, prochandle)})
                         self.sourcepids.append(processid)
-                        self.targethandles.append(prochandle)  
+                        self.targethandles.append(prochandle)
                     self.mark_call()
                     self.ret = True
 

--- a/modules/signatures/windows/memory_scraping.py
+++ b/modules/signatures/windows/memory_scraping.py
@@ -29,12 +29,21 @@ class ReadsMemoryRemoteProcess(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ret = False
+        self.handles = []
+        self.sourcepids = []
+        self.targethandles = []
 
     def on_call(self, call, process):
             prochandle = self.get_argument(call, "ProcessHandle")
             if prochandle not in ["0x00000000","0x0000000000000000","0xffffffff","0xffffffffffffffff"]:
                 buf = self.get_argument(call, "Buffer")
                 if len(buf) > 0:
+                    pname = process["process_name"].lower()
+                    processid = process["process_id"]
+                    if processid not in self.sourcepids and prochandle not in self.targethandles:
+                        self.data.append({"read_memory": "Process %s with process ID %s read from the memory of process handle %s" % (pname, processid, prochandle)})
+                        self.sourcepids.append(processid)
+                        self.targethandles.append(prochandle)  
                     self.mark_call()
                     self.ret = True
 


### PR DESCRIPTION
This signature is to detect memory scraping type behaviours. This could be for credential theft, information theft or injection.

For example here it is for injection in shadowpad/poisonplug (79c2c656eac34f628406855c9fafe36161ac423c071d9b20b64f4f511c9ec241)
![image](https://github.com/user-attachments/assets/e0e65ccd-ef2a-490e-8c0d-277063190213)
