### PR TITLE
Add signature for PE overlay

### DIFF
--- a/modules/signatures/all/static_pe_anomaly.py
+++ b/modules/signatures/all/static_pe_anomaly.py
@@ -272,16 +272,14 @@ class ContainsPEOverlay(Signature):
     minimum = "1.3"
 
     def run(self):
-        target = self.results.get("target", {})
-        if target.get("category") in ("file", "static") and target.get("file"):
-            pe = self.results["target"]["file"].get("pe", [])
-            if pe:
-                overlay = pe["overlay"]
-                if overlay:
-                    offset = overlay["offset"]
-                    size = int(overlay["size"], 16)
-                    self.data.append({"overlay": "Contains overlay at offset %s with size %s bytes" % (offset, size)})
-                    return True
+        if self.results.get("info", {}).get("category", "") in ("file", "static"):
+            overlay = self.results.get("target", {}).get("file", {}).get("pe", {}).get("overlay", {})
+            if not overlay:
+                return False
 
-        return False
+            offset = overlay["offset"]
+            size = int(overlay["size"], 16)
+            self.data.append({"overlay": f"Contains overlay at offset {offset} with size: {size} bytes"})
+            return True
+
         return False

--- a/modules/signatures/all/static_pe_anomaly.py
+++ b/modules/signatures/all/static_pe_anomaly.py
@@ -261,4 +261,27 @@ class PECompileTimeStomping(Signature):
                         self.data.append({"anomaly": "Compilation timestamp is in the future"})
                         return True
 
+class ContainsPEOverlay(Signature):
+    name = "contains_pe_overlay"
+    description = "The PE file contains an overlay"
+    severity = 2
+    confidence = 100
+    weight = 1
+    categories = ["static"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+
+    def run(self):
+        target = self.results.get("target", {})
+        if target.get("category") in ("file", "static") and target.get("file"):
+            pe = self.results["target"]["file"].get("pe", [])
+            if pe:
+                overlay = pe["overlay"]
+                if overlay:
+                    offset = overlay["offset"]
+                    size = int(overlay["size"], 16)
+                    self.data.append({"overlay": "Contains overlay at offset %s with size %s bytes" % (offset, size)})
+                    return True
+
+        return False
         return False


### PR DESCRIPTION
Add signature to highlight overlay. For example (shadowpad):

![image](https://github.com/user-attachments/assets/17a2027e-6219-4eae-8c54-f0516eb86296)

That contains a rar overlay that has additional payloads embedded in it
![image](https://github.com/user-attachments/assets/595d9b21-3a8e-46e3-b4a6-61e31c18464f)

