### PR TITLE
Create antisandbox_mousemovement.py

### DIFF
--- a/modules/signatures/windows/antisandbox_mousemovement.py
+++ b/modules/signatures/windows/antisandbox_mousemovement.py
@@ -23,6 +23,7 @@ class MouseMovementDetect(Signature):
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
+    ttps = ["T1497"]  # MITRE v6,7,8
 
     filter_apinames = set(["GetCursorPos"])
 

--- a/modules/signatures/windows/antisandbox_mousemovement.py
+++ b/modules/signatures/windows/antisandbox_mousemovement.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2025 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class MouseMovementDetect(Signature):
+    name = "mouse_movement_detect"
+    description = "Checks for mouse movement"
+    severity = 2
+    categories = ["anti-sandbox"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    filter_apinames = set(["GetCursorPos"])
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+        self.last_x = 0
+        self.last_y = 0
+        self.nomovement_count = 0
+        self.movement_count = 0
+        
+        self.ignoreprocs = [
+            "acrobat.exe",
+            "acrord32.exe",
+            "chrome.exe",
+            "excel.exe",
+            "hwp.exe",
+            "iexplore.exe",
+            "firefox.exe",
+            "msedge.exe",
+            "outlook.exe",
+            "powerpnt.exe",
+            "winword.exe",
+        ]
+
+    def on_call(self, call, process):
+        pname = process["process_name"].lower()
+        if pname not in self.ignoreprocs:
+            xpos = self.get_argument(call, "x")
+            ypos = self.get_argument(call, "y")
+
+            if xpos and ypos:
+                x = int(xpos, 16)
+                y = int(ypos, 16)
+
+                if self.last_x == 0 and self.last_y == 0:
+                        self.last_x = x
+                        self.last_y = y
+                        self.mark_call()
+                elif x == self.last_x and y == self.last_y:
+                    self.nomovement_count += 1
+                    self.mark_call()
+                    self.call_count += 1
+                elif x != self.last_x or y != self.last_y:
+                    self.movement_count += 1
+                    self.last_x = x
+                    self.last_y = y
+                    self.mark_call()
+
+    def on_complete(self):
+        if self.nomovement_count > 15 and self.movement_count < 2:
+            self.data.append({"mouse_movement": "Checks for mouse movement (no mouse movement observed in sandbox during many of the samplings)."})
+            self.ret = True
+        elif self.movement_count > 5:
+            self.data.append({"mouse_movement": "Checks for mouse movement (mouse movement observed in sandbox during sampling)."})
+            self.ret = True
+
+        return self.ret


### PR DESCRIPTION
Signature for detecting mouse movement in the sandbox. 

There is a simple exclusion list for any problem processes for now although determining if a process creates a GUI window too may be an additional method I may implement later (although I expect most will expect button presses).

Checked on Lumma sample b14ddf64ace0b5f0d7452be28d07355c1c6865710dbed84938e2af48ccaa46cf

No mouse movement (weirdly there was always the first 2 like there was movement during sandbox/sample initialisation before it moved to no movement so I have accounted for that first initial "movement"). This was emulated with disable interaction option when submitting sample.
![image](https://github.com/user-attachments/assets/cb48796a-7aaa-434b-b5b3-0b54d4ebf2a6)

And with mouse movement. I opted for a lower value for this to trigger as sometimes it took not as many samples but with nomouse movement it would continuously poll until it saw some
![image](https://github.com/user-attachments/assets/6037ed6b-5ef4-4093-b4ea-de7f9698587d)
