### PR TITLE
Fix injection_thread.py

### DIFF
--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -35,8 +35,9 @@ class ThreadManipulationRemoteProcess(Signature):
         self.targetpid = []
 
     def on_call(self, call, process):
-        procid = self.get_argument(call, "ProcessId")
+        procid = int(self.get_argument(call, "ProcessId"))
         processid = process["process_id"]
+
         if procid != processid:
             if processid not in self.sourcepid and procid not in self.targetpid:
                 pname = process["process_name"].lower()


### PR DESCRIPTION
`self.get_argument` returns a string so whether the target process and source process are equal or not, it always be true, so we need to convert it to integer